### PR TITLE
LANMgr-Netlink code to monitor interface up status

### DIFF
--- a/config/LanManager.service
+++ b/config/LanManager.service
@@ -9,6 +9,7 @@ Environment="LOG4C_RCPATH=/etc"
 EnvironmentFile=/etc/device.properties
 ExecStartPre=/bin/sh -c '(/usr/ccsp/utopiaInitCheck.sh)'
 ExecStart=/usr/bin/lan_manager
+ExecStart=sh -c '/usr/bin/lan_netlinkifmonitor &'
 ExecStop=/bin/sh -c 'echo "`date`: Stopping/Restarting LanManager" >> ${PROCESS_RESTART_LOG}'
 Restart=always
 

--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,7 @@ PKG_CHECK_MODULES([DBUS],[dbus-1 >= 1.6.18])
 AC_CONFIG_FILES([Makefile
            	source/Makefile
                 source/LanMgrMain/Makefile
+                source/LanMgrTest/Makefile
 			])
                         
 AM_CONDITIONAL([PLATFORM_RASPBERRYPI_ENABLED], [test $PLATFORM_RASPBERRYPI_ENABLED = yes])

--- a/source/LanMgrTest/Makefile.am
+++ b/source/LanMgrTest/Makefile.am
@@ -1,0 +1,30 @@
+##########################################################################
+# If not stated otherwise in this file or this component's LICENSE
+# file the following copyright and licenses apply:
+#
+# Copyright 2017 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+bin_PROGRAMS = lan_netlinkifmonitor
+
+AM_CPPFLAGS =   -I$(top_srcdir)/source/include \
+                -I$(top_srcdir)/source/LanMgrTest \
+                -I=${includedir} \
+                -I=${includedir}/ccsp
+AM_CFLAGS = -D_ANSC_LINUX -D_ANSC_USER -D_ANSC_LITTLE_ENDIAN_ -DFEATURE_SUPPORT_RDKLOG $(DBUS_CFLAGS)
+AM_LDFLAGS = -lsysevent -lsyscfg -lsecure_wrapper -ltelemetry_msgsender
+AM_LDFLAGS = $(DBUS_LIBS)
+lan_netlinkifmonitor_LDFLAGS = -lsysevent -lsyscfg
+lan_netlinkifmonitor_SOURCES = lan_netlinkifmonitor.c
+

--- a/source/LanMgrTest/lan_netlinkifmonitor.c
+++ b/source/LanMgrTest/lan_netlinkifmonitor.c
@@ -1,0 +1,96 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/socket.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <net/if.h>
+
+// Buffer size for netlink messages
+#define NL_BUFSIZE 8192
+
+// Logging macro
+#define monitor_log(fmt, ...)   fprintf(stderr, "[DEBUG] " fmt "\n", ##__VA_ARGS__)
+
+
+// Helper: parse attributes
+static void parse_attributes(struct rtattr *tb[], int max, struct rtattr *rta, int len) {
+    while (RTA_OK(rta, len)) {
+        if (rta->rta_type <= max)
+            tb[rta->rta_type] = rta;
+        rta = RTA_NEXT(rta, len);
+    }
+}
+
+// Function to handle link events
+void handle_link_event(struct nlmsghdr *nlh) {
+    struct ifinfomsg *ifi = NLMSG_DATA(nlh);
+    int len = nlh->nlmsg_len - NLMSG_LENGTH(sizeof(*ifi));
+    struct rtattr *tb[IFLA_MAX + 1];
+    memset(tb, 0, sizeof(tb));
+
+    parse_attributes(tb, IFLA_MAX, IFLA_RTA(ifi), len);
+
+    const char *ifname = NULL;
+    if (tb[IFLA_IFNAME]) {
+        ifname = (char *)RTA_DATA(tb[IFLA_IFNAME]);
+    }
+
+    if (nlh->nlmsg_type == RTM_NEWLINK) {
+        printf("Interface added/updated: %s (index %d)\n", 
+               ifname ? ifname : "unknown", ifi->ifi_index);
+    } else if (nlh->nlmsg_type == RTM_DELLINK) {
+        printf("Interface deleted: %s (index %d)\n", 
+               ifname ? ifname : "unknown", ifi->ifi_index);
+    }
+}
+
+int main() {
+    int sockfd;
+    struct sockaddr_nl sa;
+    char buf[NL_BUFSIZE];
+
+    // Create netlink socket
+    sockfd = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+    if (sockfd < 0) {
+        perror("socket");
+        return 1;
+    }
+
+    memset(&sa, 0, sizeof(sa));
+    sa.nl_family = AF_NETLINK;
+    sa.nl_groups = RTMGRP_LINK; // Listen for link events
+
+    if (bind(sockfd, (struct sockaddr *)&sa, sizeof(sa)) < 0) {
+        perror("bind");
+        close(sockfd);
+        return 1;
+    }
+
+    printf("Listening for interface create/delete events...\n");
+
+    while (1) {
+        int len = recv(sockfd, buf, sizeof(buf), 0);
+        if (len < 0) {
+            if (errno == EINTR) continue;
+            perror("recv");
+            break;
+        }
+
+        struct nlmsghdr *nlh;
+        for (nlh = (struct nlmsghdr *)buf; NLMSG_OK(nlh, len); nlh = NLMSG_NEXT(nlh, len)) {
+            if (nlh->nlmsg_type == NLMSG_DONE)
+                break;
+            if (nlh->nlmsg_type == NLMSG_ERROR) {
+                fprintf(stderr, "Received netlink error\n");
+                continue;
+            }
+            handle_link_event(nlh);
+        }
+    }
+
+    close(sockfd);
+    return 0;
+}

--- a/source/LanMgrTest/lan_netlinkifmonitor.c
+++ b/source/LanMgrTest/lan_netlinkifmonitor.c
@@ -1,19 +1,19 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
+#include <string.h>
 #include <errno.h>
 #include <sys/socket.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <net/if.h>
 
-// Buffer size for netlink messages
 #define NL_BUFSIZE 8192
+#define MAX_INTERFACES 32   // Max interfaces we allow as arguments
 
-// Logging macro
-#define monitor_log(fmt, ...)   fprintf(stderr, "[DEBUG] " fmt "\n", ##__VA_ARGS__)
-
+// Store interface list
+static const char *monitored_ifaces[MAX_INTERFACES];
+static int monitored_count = 0;
 
 // Helper: parse attributes
 static void parse_attributes(struct rtattr *tb[], int max, struct rtattr *rta, int len) {
@@ -24,13 +24,28 @@ static void parse_attributes(struct rtattr *tb[], int max, struct rtattr *rta, i
     }
 }
 
+// ✅ Callback function when interface comes UP
+void on_interface_up(const char *ifname, int ifindex) {
+    printf(">>> CALLBACK: Interface %s (index %d) is UP <<<\n", ifname, ifindex);
+}
+
+// Function to check if interface is in monitored list
+static int is_monitored(const char *ifname) {
+    for (int i = 0; i < monitored_count; i++) {
+        if (strcmp(monitored_ifaces[i], ifname) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 // Function to handle link events
 void handle_link_event(struct nlmsghdr *nlh) {
     struct ifinfomsg *ifi = NLMSG_DATA(nlh);
     int len = nlh->nlmsg_len - NLMSG_LENGTH(sizeof(*ifi));
+
     struct rtattr *tb[IFLA_MAX + 1];
     memset(tb, 0, sizeof(tb));
-
     parse_attributes(tb, IFLA_MAX, IFLA_RTA(ifi), len);
 
     const char *ifname = NULL;
@@ -38,16 +53,33 @@ void handle_link_event(struct nlmsghdr *nlh) {
         ifname = (char *)RTA_DATA(tb[IFLA_IFNAME]);
     }
 
+    if (!ifname || !is_monitored(ifname)) {
+        return; // Ignore interfaces we don't care about
+    }
+
     if (nlh->nlmsg_type == RTM_NEWLINK) {
-        printf("Interface added/updated: %s (index %d)\n", 
-               ifname ? ifname : "unknown", ifi->ifi_index);
-    } else if (nlh->nlmsg_type == RTM_DELLINK) {
-        printf("Interface deleted: %s (index %d)\n", 
-               ifname ? ifname : "unknown", ifi->ifi_index);
+        if (ifi->ifi_flags & IFF_UP) {
+            on_interface_up(ifname, ifi->ifi_index);
+        }
     }
 }
 
-int main() {
+int main(int argc, char *argv[]) {
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <iface1> [iface2] ... [ifaceN]\n", argv[0]);
+        return 1;
+    }
+
+    // Save monitored interfaces
+    monitored_count = argc - 1;
+    if (monitored_count > MAX_INTERFACES) {
+        fprintf(stderr, "Too many interfaces (max %d)\n", MAX_INTERFACES);
+        return 1;
+    }
+    for (int i = 1; i < argc; i++) {
+        monitored_ifaces[i-1] = argv[i];
+    }
+
     int sockfd;
     struct sockaddr_nl sa;
     char buf[NL_BUFSIZE];
@@ -69,7 +101,10 @@ int main() {
         return 1;
     }
 
-    printf("Listening for interface create/delete events...\n");
+    printf("Monitoring %d interfaces for UP events:\n", monitored_count);
+    for (int i = 0; i < monitored_count; i++) {
+        printf("  - %s\n", monitored_ifaces[i]);
+    }
 
     while (1) {
         int len = recv(sockfd, buf, sizeof(buf), 0);

--- a/source/Makefile.am
+++ b/source/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS =  LanMgrMain
+SUBDIRS =  LanMgrMain LanMgrTest


### PR DESCRIPTION
Reason for change: 
This binary will accept a list of interfaces.
This binary shall monitor the interface status and trigger a callback function when the interface comes up
Lan manager will add to a list or array on which all interface net link code should monitor

Gerrit link:
https://gerrit.teamccp.com/#/c/926921/

Logs:
[NetLink.txt](https://github.com/user-attachments/files/22679875/NetLink.txt)

Test Procedure:
  - TBD
